### PR TITLE
PP-1807 Fix reboots required control description

### DIFF
--- a/aws_compliance.py
+++ b/aws_compliance.py
@@ -103,7 +103,7 @@ def reboots_required():
     failReason = ""
     offenders = []
     control = "reboots_required"
-    description = "Instances requiring a reboot i.e. have a `/var/run/reboot-required`"
+    description = "Instances requiring a reboot, see /var/log/pay-reboots-required.log on instances"
     scored = False
     filters = [{'Name':'tag:reboots_required', 'Values':['true']}]
     reservations = EC2_CLIENT.describe_instances(Filters=filters).get('Reservations', [])


### PR DESCRIPTION
There are now a few reasons why an instance may be tagged as 
`reboots-required: true`.

1) /var/run/reboot-required is present
2) processes needing a restart due to an upgrade and using old libs

point folk to the log file on instances which points to one reason or  
another. In all likelihood, the action will be the same, restart the
instance or roll a new AMI.