### PR TITLE
BAU: Add command line args to compliance script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ that fail compliance in some way.
 The script can be run independently with
 
 ```
-python aws_compliance.py
+./aws_compliance.py -h # Help message
+./aws_compliance.py -e # Dry-run: echo variables
+./aws_compliance.py    # Run the reports
 ```
 
 or as part of a scheduled Lambda function, or by AWS Config.
@@ -34,12 +36,7 @@ or as part of a scheduled Lambda function, or by AWS Config.
 |ONLY\_SHOW\_FAILED | false | Only show failed compliance checks |
 |S3\_BUCKETS\_TO_SKIP | None | CSV of S3 buckets to skip compliance checks |
 |VULS\_REPORT\_BUCKET | pay-govuk-dev-vuls | S3 bucket to find Vuls reports |
-|VULS\_HIGH\_THRESHOLD | 7 | Vuls High score threshold |
-|VULS\_MEDIUM\_THRESHOLD | 4.5 | Vuls Medium score threshold |
-|VULS\_LOW\_THRESHOLD | 0 | Vuls Low score threshold |
-|VULS\_UNKNOWN\_THRESHOLD | -1 | Vuls Unknown score threshold |
-|VULS\_IGNORE\_UNSCORED_CVE | True | Vuls report should ignore unscored CVEs? |
-|VULS\_MIN\_ALERT_SEVERITY | 'medium' | Vuls only reports on this severity or higher
+|UNIX\_ACCOUNT\_REPORT\_BUCKET | pay-govuk-unix-accounts-dev | S3 bucket where unix account reports are stored |
 
 ## Interpreting the compliance report
 


### PR DESCRIPTION
This script is run from λ but also run as a BAU/support process.

Using environment variables is an ugly when being run from a terminal.

This PR adds arg parsing while still being backwards compatible with the λ
runner. (https://github.com/alphagov/pay-infra/blob/4c014ca28d8fdce0c051947b8f84b62f3ddacfd5/provisioning/resources/terraforms/s3_event_logging/aws_compliance.tf)

To test this run:
```
ONLY_SHOW_FAILED=true \
REGION=eu-west-1 \
S3_BUCKETS_TO_SKIP=pay-govuk-terraform-state-ci-eu-central-1,pay-govuk-terraform-state-deploy-eu-central-1 \
SEND_REPORT_TO_SNS=true \
SNS_TOPIC_ARN=aws_sns_topic.aws_compliance.arn \
VULS_REPORT_BUCKET=pay-govuk-aws-account-vuls \
UNIX_ACCOUNT_REPORT_BUCKET=pay-govuk-unix-accounts-aws-account \
./aws_compliance.py -e
```

There is also a help message when you run:
```
./aws_compliance.py -h
```

And you can see the values of the variables (dry run) with:
```
./aws_compliance.py -e
```

I haven't yet tested this with λ yet.

solo @tlwr