### PR TITLE
[BAU] Fix AWS Compliance Script for Python 3.

### DIFF
--- a/aws_compliance.py
+++ b/aws_compliance.py
@@ -451,10 +451,10 @@ def unix_account_last_login_reports():
                     if account not in unused_unix_accounts_by_instance[instance]:
                         unused_unix_accounts_by_instance[instance].append(account)
             # filter instances less than 90 days
-            for instance in unused_unix_accounts_by_instance.keys():
-                if instance not in instances_in_scope(unused_unix_accounts_by_instance.keys()):
+            for instance in list(unused_unix_accounts_by_instance):
+                if instance not in instances_in_scope(list(unused_unix_accounts_by_instance)):
                     del unused_unix_accounts_by_instance[instance]
-            if len(unused_unix_accounts_by_instance.keys()) > 0:
+            if len(list(unused_unix_accounts_by_instance)) > 0:
                 result = False
                 failReason = "Unix accounts found with last login over 90 days ago"
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 astroid==2.4.2
 autopep8==1.5.4
-awscli==1.18.133
+awscli==1.18.153
 boto==2.49.0
-boto3==1.4.4
-botocore==1.17.56
+boto3==1.15.12
+botocore==1.18.12
 colorama==0.4.3
 docutils==0.15.2
 isort==5.5.1


### PR DESCRIPTION
## What?
Whilst trying to run the AWS Compliance script, I have discovered that the behaviour of `.keys()` has changed between Python 2 and Python 3. This previously presented a list data type, but as of Python 3, the default behaviour now returns a dict_keys data type.

I have replaced all instances of `x.keys()` with `list(x)`.

I have also updated `requirements.txt`