### PR TITLE
[PP-6878] Bump version to 0.1.0 along with move to Python 3.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-VERSION="0.0.7"
+VERSION="0.1.0"
 
 IFS=$'\n\t'
 
@@ -20,7 +20,7 @@ TARGET=s3://"${S3_BUCKET}"/"${ARTIFACT}"
 TMP_DIR=$(mktemp -d /tmp/lambda-XXXXXX)
 ZIPFILE="${TMP_DIR}"/"${ARTIFACT}"
 
-virtualenv -p /usr/bin/python2.7 venv
+virtualenv -p /usr/bin/python3 venv
 . ./venv/bin/activate
 ./venv/bin/python ./venv/bin/pip install -qUr requirements.txt
 


### PR DESCRIPTION
## What's this?
This bumps the version number of the script from 0.0.8 and up to 0.1.0. Whilst the changes have been relatively minor, a few changes have been made to enable the move to Python 3.8. Therefore, I consider this a "major" version and worthy of a bump to wave farewell to Python 2.7!