### PR TITLE
PP-8584: Exclude deploy account from EC2 reports

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,16 +118,18 @@
         "filename": "aws_compliance.py",
         "hashed_secret": "08d2e98e6754af941484848930ccbaddfefe13d6",
         "is_verified": false,
-        "line_number": 265
+        "is_secret": false,
+        "line_number": 269
       },
       {
         "type": "Secret Keyword",
         "filename": "aws_compliance.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 311
+        "is_secret": false,
+        "line_number": 315
       }
     ]
   },
-  "generated_at": "2021-08-13T15:48:18Z"
+  "generated_at": "2021-09-07T16:11:22Z"
 }

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-VERSION="0.1.1"
+VERSION="0.2.0"
 
 IFS=$'\n\t'
 


### PR DESCRIPTION
There are no longer any EC2 instances in the `deploy` account. The empty reports are causing noise in Zendesk.

The Python script is not in great shape 😿 However I've restrained myself from completely refactoring it as we intend to rewrite it in NodeJS. There aren't any unit tests for this script (😿 😿 ) so any changes should be simple enough that we can have confidence the reports will still meet our protective monitoring needs. 

- In practice, the change below simply skips the EC2-related reports for the deploy account (this lambda uses its alias `govuk-pay-deploy` is used rather than the account ID)
- Once we've turned off all EC2 instances in other accounts, we can gradually expand the `ACCOUNTS_WITHOUT_EC2_INSTANCES` list with some more aliases as we go.
- Using the double-negative (`not in ACCOUNTS_WITHOUT...`) feels a bit iffy, but to me that naming it makes it clearer why the clause is there. Happy to be persuaded otherwise.
- A small change was also needed for the secrets baseline to mark a couple of lines as false positives.

Tested locally that the compliance report still works on EC2 accounts (eg `govuk-pay-test`) and skips the EC2 reports for deploy.

Paired with @dj-maisy 