### PR TITLE
Pp 7505 update after instance retirement

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,18 +118,18 @@
         "filename": "aws_compliance.py",
         "hashed_secret": "08d2e98e6754af941484848930ccbaddfefe13d6",
         "is_verified": false,
-        "is_secret": false,
-        "line_number": 269
+        "line_number": 271,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "aws_compliance.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "is_secret": false,
-        "line_number": 315
+        "line_number": 317,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2021-09-07T16:11:22Z"
+  "generated_at": "2022-02-04T12:11:55Z"
 }

--- a/aws_compliance.py
+++ b/aws_compliance.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import argparse
 from datetime import datetime
 import csv
@@ -11,7 +10,10 @@ import time
 
 FALSE_VALUES = ['f', 'false', 'none']
 
-ACCOUNTS_WITHOUT_EC2_INSTANCES = [
+ACCOUNTS_WITHOUT_EC2_APP_INSTANCES = [
+    'govuk-pay-test'
+    'govuk-pay-staging'
+    'govuk-pay-production'
     'govuk-pay-deploy'
 ]
 
@@ -764,7 +766,7 @@ def lambda_handler(event, context):
     controls.append(old_api_keys(cred_report))
 
     # EC2 related compliance
-    if account_alias not in ACCOUNTS_WITHOUT_EC2_INSTANCES:
+    if account_alias not in ACCOUNTS_WITHOUT_EC2_APP_INSTANCES:
         controls.append(reboots_required())
         controls.append(vuls_reports())
         controls.append(unix_account_last_login_reports())

--- a/aws_compliance.py
+++ b/aws_compliance.py
@@ -11,10 +11,10 @@ import time
 FALSE_VALUES = ['f', 'false', 'none']
 
 ACCOUNTS_WITHOUT_EC2_APP_INSTANCES = [
-    'govuk-pay-test'
-    'govuk-pay-staging'
-    'govuk-pay-production'
-    'govuk-pay-deploy'
+    'govuk-pay-test',
+    'govuk-pay-staging',
+    'govuk-pay-production',
+    'govuk-pay-deploy',
 ]
 
 app_description = """

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,0 +1,3 @@
+awscliv2==2.0.2
+importlib-resources==5.4.0
+zipp==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
-awscli==1.19.20
-boto3==1.17.17
-botocore==1.20.20
-colorama==0.4.4
-docutils==0.16
+# These are the versions provided by AWS Lambda for python 3.6 through 3.9
+boto3==1.18.55
+botocore==1.21.55
 jmespath==0.10.0
-pyasn1==0.4.8
-python-dateutil==2.8.1
-PyYAML==5.4.1
-rsa==4.7.2
-s3transfer==0.3.4
-six==1.15.0
-urllib3==1.26.5
+python-dateutil==2.8.2
+s3transfer==0.5.1
+six==1.16.0
+urllib3==1.26.8


### PR DESCRIPTION
# What?

1. Add test, staging, production as accounts without EC2 app instances (and rename the variable to EC2_APP instances since it's confusing now)
2. Update the secrets baseline
3. Remove the python2 `from __future__ import print_function` (this gave python2 python3 print compatibility)
4. Bump the version number
5. Fix the build
    1. Change the requirements.txt file so it only specifies boto3 and it's dependencies, and use the exact versions that aws provide by default for lambdas in python 3.8
    2. Add requirements.build.txt which just provides the awscli (and a newer version than was used in the original requirements since that now provokes version conflicts)
    3. Change the build script so it doesn't use system python3 (which changes as ~OSx~MacOS updates)
    4. Only include the aws_compliance.py file in the built zip file (we don't need any of the rest and the pip install wasn't even being used because it was built to the wrong place) 
    5. Update the help text so it's easier for a newcomer to get to grips with
    6. Stop using the virtualenv command (long deprecated) and instead use the python3 built in module venv
  
# How
You can test locally by:
```
$ python3 -m venv venv
$ source venv/bin/activate
$ pip install -r requirements.txt
$ aws-vault exec test -- ./aws_compliance.py
```

For added safety we can deploy this to the test account and manually run the lambda (after warning the support personnel that they may get an alert)