### PR TITLE
PP-7505: Fix production account name in exclusion list

### DIFF
--- a/aws_compliance.py
+++ b/aws_compliance.py
@@ -13,7 +13,7 @@ FALSE_VALUES = ['f', 'false', 'none']
 ACCOUNTS_WITHOUT_EC2_APP_INSTANCES = [
     'govuk-pay-test',
     'govuk-pay-staging',
-    'govuk-pay-production',
+    'govuk-pay-prod',
     'govuk-pay-deploy',
 ]
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-VERSION="0.3.0"
+VERSION="0.3.1"
 
 IFS=$'\n\t'
 


### PR DESCRIPTION
The production account name was incorrect in my previous PR. This fixes the account name to be govuk-pay-prod.

# How to test

Note: This test assumes bash/zsh, if you are a fish user source `venv/bin/activate.fish` instead

```
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt
aws-vault exec production -- ./aws_compliance.py | jq .[].Result
```

This will show all tests passed with Result being `true` for every test.
